### PR TITLE
Fix atom feed min version param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 expath-pkg.xml
+.existdb.json

--- a/modules/feed.xql
+++ b/modules/feed.xql
@@ -15,7 +15,13 @@ declare function local:feed-entries() {
                 $repoURL || "public/" || $app/icon[1]
         else
             $repoURL || "resources/images/package.png"
-    let $info-url := concat($repoURL, 'packages/', $app/abbrev, '.html')
+    let $info-url :=
+        concat($repoURL, 'packages/', $app/abbrev, '.html',
+            if ($app/requires/@*[not(name() = 'processor')]) then
+                concat('?eXist-db-min-version=', ($app/requires/@version, $app/requires/@semver-min)[1])
+            else
+                ()
+        )
     let $title := $app/title
     let $version := $app/version
     let $authors := $app/author

--- a/modules/find.xql
+++ b/modules/find.xql
@@ -18,14 +18,13 @@ let $apps :=
     else
         collection($config:app-root || "/public")//app[abbrev = $abbrev]
 let $path := app:find-version($apps | $apps/other/version, $procVersion, $version, $semVer, $minVersion, $maxVersion)
-let $app := $path/..
 return
     if ($path) then
         let $xar := util:binary-doc($config:app-root || "/public/" || $path)
         return
             if ($zip) then
                 let $entry :=
-                    <entry type="binary" method="store" name="/{$app/@path}" strip-prefix="false">{$xar}</entry>
+                    <entry type="binary" method="store" name="/{$path}" strip-prefix="false">{$xar}</entry>
                 let $zip := compression:zip($entry, false())
                 return
                     response:stream-binary($zip, "application/zip", "pkg.zip")


### PR DESCRIPTION
When @dizzzz's updated replication xar appeared in my feed reader today, the link to it yielded an error:

![screen shot 2017-01-08 at 2 39 07 pm](https://cloud.githubusercontent.com/assets/59118/21752979/5e217588-d5b0-11e6-96e7-bdb6b2b5d77d.png)

This PR ports an [earlier fix](https://github.com/eXist-db/public-xar-repo/commit/c4be8005353d4d18b693ea0b4e9b13f858853d9f) to this issue elsewhere in the app to the atom feed module.

With this update, the feed should now direct readers to the correct URL:

http://demo.exist-db.org/exist/apps/public-repo/packages/jms.html?eXist-db-min-version=3.0.3