### PR TITLE
Fix icon width

### DIFF
--- a/resources/css/packageManager.css
+++ b/resources/css/packageManager.css
@@ -64,7 +64,7 @@
   position: relative;
 }
 #listWrapper .packageIconArea .appIcon {
-  max-width: 64px;
+  width: 64px;
   max-height: 64px;
 }
 #listWrapper .packageIconArea .appFunctions {


### PR DESCRIPTION
Before the new launcher app's icon appeared tiny - 24x24 on http://demo.exist-db.org/exist/apps/public-repo/index.html and http://demo.exist-db.org/exist/apps/public-repo/packages/launcher.html. This makes the launcher app's icon the right size.

Before:

> <img width="391" alt="screen shot 2018-06-11 at 11 30 12 pm" src="https://user-images.githubusercontent.com/59118/41268768-ccbdebda-6dcf-11e8-9cb8-a1575af0e344.png">

After:

> <img width="329" alt="screen shot 2018-06-11 at 11 29 56 pm" src="https://user-images.githubusercontent.com/59118/41268772-d2db096c-6dcf-11e8-97bc-850790ddb42a.png">