### PR TITLE
Explicitly set Content-Type application/xml to avoid text/plain override

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -13,11 +13,13 @@ if ($exist:path eq "/") then
         <redirect url="index.html"/>
     </dispatch>
 
-else if ($exist:path = "/public/apps.xml") then
+else if ($exist:path = "/public/apps.xml") then (
+    response:set-header('Content-Type', 'application/xml'),
+    
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="{$exist:controller}/modules/list.xql"/>
     </dispatch>
-    
+)
 else if ($exist:resource = "update.xql") then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="{$exist:controller}/modules/update.xql"/>


### PR DESCRIPTION
https://github.com/eXist-db/public-xar-repo/issues/17

controller.xql will return text/plain without this explicit Content-Type application/xml. When the content-type is text/plain, the Package Manager on a client will not function properly and run into a type error in function packages:public-repo-contents when it does $data[2]//app on a string.