### PR TITLE
Improves the naming of dowloaded XAR packages

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -76,6 +76,11 @@ else if (ends-with($exist:resource, ".html")) then
         </view>
     </dispatch>
 
+else if (contains($exist:path, "/public/") and ends-with($exist:resource, ".zip")) then
+    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+        <forward url="../modules/download-xar-zip.xq"/>
+    </dispatch>
+
 else if ($exist:resource = "find" or ends-with($exist:resource, ".zip")) then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="modules/find.xql"/>

--- a/modules/download-xar-zip.xq
+++ b/modules/download-xar-zip.xq
@@ -1,0 +1,17 @@
+xquery version "3.0";
+
+import module namespace compression="http://exist-db.org/xquery/compression";
+import module namespace response="http://exist-db.org/xquery/response";
+import module namespace util="http://exist-db.org/xquery/util";
+
+import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
+
+let $pkg-file-name := fn:replace(request:get-url(), ".*/(.*)\.zip", "$1")
+let $xar := util:binary-doc($config:app-root || "/public/" || $pkg-file-name)
+return
+    let $entry :=
+        <entry type="binary" method="store" name="/{$pkg-file-name}" strip-prefix="false">{$xar}</entry>
+    let $zip := compression:zip($entry, false())
+    return
+        response:stream-binary($zip, "application/zip")
+

--- a/modules/find.xql
+++ b/modules/find.xql
@@ -1,5 +1,8 @@
 xquery version "3.0";
 
+import module namespace request="http://exist-db.org/xquery/request";
+import module namespace response="http://exist-db.org/xquery/response";
+
 import module namespace app="http://exist-db.org/xquery/app" at "app.xql";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
 import module namespace scanrepo="http://exist-db.org/xquery/admin/scanrepo" at "scan.xql";
@@ -20,16 +23,10 @@ let $apps :=
 let $path := app:find-version($apps | $apps/other/version, $procVersion, $version, $semVer, $minVersion, $maxVersion)
 return
     if ($path) then
-        let $xar := util:binary-doc($config:app-root || "/public/" || $path)
-        return
-            if ($zip) then
-                let $entry :=
-                    <entry type="binary" method="store" name="/{$path}" strip-prefix="false">{$xar}</entry>
-                let $zip := compression:zip($entry, false())
-                return
-                    response:stream-binary($zip, "application/zip", "pkg.zip")
-            else
-                response:stream-binary($xar, "application/zip", $path)
+        if ($zip) then
+            response:redirect-to(xs:anyURI("public/" || $path || ".zip"))
+        else 
+            response:redirect-to(xs:anyURI("public/" || $path))
     else (
         response:set-status-code(404),
         <p>Package file {$path} not found!</p>


### PR DESCRIPTION
1. Previously when downloading a zipped XAR package using the `find` API via either of the URIs:
    * http://demo.exist-db.org/exist/apps/public-repo/find?zip=yes&abbrev=shared&processor=4.4.0
    * http://demo.exist-db.org/exist/apps/public-repo/pkg.zip?zip=yes&abbrev=shared&processor=4.4.0

    You would be given a file named `pkg.zip`. This was quite confusing. Sure the HTTP Response `Content-Disposition` header indicated the real filename but it was not pretty at all, also some HTTP clients would ignore that header.

2. Previously when downloading a (non-zipped) XAR package using the `find` API via either of the URIs:
    * http://demo.exist-db.org/exist/apps/public-repo/find?abbrev=shared&processor=4.4.0
    * http://demo.exist-db.org/exist/apps/public-repo/pkg.zip?abbrev=shared&processor=4.4.0

    You would be given a file named either `find` or `pkg.zip`. This was especially bad as the file was not zipped!

This patch instead offers a kinder approach. It HTTP redirects you to the correct filename. For example, a zipped XAR package would be named like `shared-resources-0.8.2.xar.zip`, and a non-zipped XAR package would be named like `shared-resources-0.8.2.xar`.

Due to the wonders of HTTP redirects. These changes *should* be backwards compatible with existing tools that use the Public Repo API.
