### PR TITLE
Support lookup of apps by legacy "abbrev"

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -5,6 +5,8 @@ import module namespace login="http://exist-db.org/xquery/login" at "resource:or
 declare variable $exist:path external;
 declare variable $exist:resource external;
 declare variable $exist:controller external;
+declare variable $exist:prefix external;
+declare variable $exist:root external;
 
 login:set-user("org.exist.public-repo.login", (), false()),
 
@@ -19,14 +21,13 @@ else if ($exist:path eq "/") then
         <redirect url="index.html"/>
     </dispatch>
 
-else if ($exist:path = "/public/apps.xml") then (
+else if ($exist:path eq "/public/apps.xml") then (
     response:set-header('Content-Type', 'application/xml'),
-    
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="{$exist:controller}/modules/list.xql"/>
     </dispatch>
 )
-else if ($exist:resource = "update.xql") then
+else if ($exist:resource eq "update.xql") then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="{$exist:controller}/modules/update.xql"/>
         <view>
@@ -40,7 +41,7 @@ else if ($exist:resource = "update.xql") then
 (:  Protected resource: user is required to log in with valid credentials.
     If the login fails or no credentials were provided, the request is redirected
     to the login.html page. :)
-else if ($exist:resource eq 'admin.html') then (
+else if ($exist:path eq "/admin.html") then
     let $user := request:get-attribute("org.exist.public-repo.login.user")
     return
         if ($user and (sm:is-dba($user) or "repo" = sm:get-user-groups($user))) then
@@ -60,14 +61,13 @@ else if ($exist:resource eq 'admin.html') then (
                     </forward>
                 </view>
             </dispatch>
-)
 
 else if (ends-with($exist:resource, ".html") and starts-with($exist:path, "/packages")) then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="{concat($exist:controller, '/packages.html')}"/>
         <view>
             <forward url="{concat($exist:controller, '/modules/view.xql')}">
-                <add-parameter name="package-id" value="{substring-before($exist:resource, '.html')}"/>
+                <add-parameter name="abbrev" value="{substring-before($exist:resource, '.html')}"/>
             </forward>
         </view>
     </dispatch>
@@ -87,12 +87,12 @@ else if (contains($exist:path, "/public/") and ends-with($exist:resource, ".zip"
         <forward url="../modules/download-xar-zip.xq"/>
     </dispatch>
 
-else if ($exist:resource = "find" or ends-with($exist:resource, ".zip")) then
+else if ($exist:path eq "/find" or ends-with($exist:resource, ".zip")) then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="modules/find.xql"/>
     </dispatch>
-    
-else if ($exist:resource = "feed.xml") then
+
+else if ($exist:resource eq "feed.xml") then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="modules/feed.xql"/>
     </dispatch>

--- a/controller.xql
+++ b/controller.xql
@@ -7,7 +7,13 @@ declare variable $exist:resource external;
 declare variable $exist:controller external;
 
 login:set-user("org.exist.public-repo.login", (), false()),
-if ($exist:path eq "/") then
+
+if ($exist:path eq "") then
+    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+        <redirect url="{request:get-uri()}/"/>
+    </dispatch>
+
+else if ($exist:path eq "/") then
     (: forward root path to index.xql :)
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <redirect url="index.html"/>

--- a/login.html
+++ b/login.html
@@ -8,7 +8,7 @@
         <div class="form-group">
             <label class="control-label col-md-1" for="user">User:</label>
             <div class="col-md-3">
-                <input type="text" name="user" required="required" class="form-control"/>
+                <input type="text" name="user" required="required" class="form-control" autofocus="autofocus"/>
             </div>
         </div>
         <div class="form-group">

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -52,7 +52,7 @@ declare function app:view-package($node as node(), $model as map(*), $mode as xs
 };
 
 declare function app:package-to-list-item($app as element(app), $show-details as xs:boolean) {
-    let $repoURL := concat(substring-before(request:get-uri(), 'public-repo/'), 'public-repo/')
+    let $repoURL := concat(substring-before(request:get-uri(), "public-repo/"), "public-repo/")
     let $icon :=
         if ($app/icon) then
             if ($app/@status) then
@@ -77,12 +77,12 @@ declare function app:package-to-list-item($app as element(app), $show-details as
             </div>
             {
                 switch ($app/type)
-                    case ('application') return
-                        <img src="{$repoURL || 'resources/images/app.gif'}" class="ribbon" alt="application" title="This is an application"/>
-                    case ('library') return
-                        <img src="{$repoURL || 'resources/images/library2.gif'}" class="ribbon" alt="library" title="This is a library"/>
-                    case ('plugin') return
-                        <img src="{$repoURL || 'resources/images/plugin2.gif'}" class="ribbon" alt="plugin" title="This is a plugin"/>
+                    case ("application") return
+                        <img src="{$repoURL || "resources/images/app.gif"}" class="ribbon" alt="application" title="This is an application"/>
+                    case ("library") return
+                        <img src="{$repoURL || "resources/images/library2.gif"}" class="ribbon" alt="library" title="This is a library"/>
+                    case ("plugin") return
+                        <img src="{$repoURL || "resources/images/plugin2.gif"}" class="ribbon" alt="plugin" title="This is a plugin"/>
                     default return ()
             }
             <h3 style="padding-bottom: 0"><a href="{$info-url}">{$app/title/text()}</a></h3>
@@ -112,7 +112,7 @@ declare function app:package-to-list-item($app as element(app), $show-details as
                         }
                         <tr>
                             <th>Short Title:</th>
-                            <td>{ $app/abbrev/text() }</td>
+                            <td>{ $app/abbrev[not(@type)]/text() }</td>
                         </tr>
                         <tr>
                             <th>Package Name (URI):</th>
@@ -120,7 +120,7 @@ declare function app:package-to-list-item($app as element(app), $show-details as
                         </tr>
                         <tr>
                             <th>Author(s):</th>
-                            <td>{string-join($app/author, ', ')}</td>
+                            <td>{string-join($app/author, ", ")}</td>
                         </tr>
                         <tr>
                             <th>License:</th>
@@ -149,12 +149,12 @@ declare function app:package-to-list-item($app as element(app), $show-details as
                                             order by $version/@version 
                                             return $version
                                         for $version at $n in $versions
-                                        let $download-version-url := concat($repoURL, 'public/', $version/@path)
+                                        let $download-version-url := concat($repoURL, "public/", $version/@path)
                                         return
                                             (
                                             <a href="{$download-version-url}">{$version/@version/string()}</a>
                                             ,
-                                            if ($n lt count($versions)) then ', ' else ()
+                                            if ($n lt count($versions)) then ", " else ()
                                             )
                                     }</td>
                                 </tr>
@@ -185,9 +185,9 @@ declare function app:package-to-list-item($app as element(app), $show-details as
                         {$app/description/text()}
                         <br/>
                         Version {$app/version/text()} {
-                            if ($app/requires) then 
-                                concat(' (Requires eXist-db ', app:requires-to-english($app/requires), '.)')
-                            else 
+                            if ($app/requires) then
+                                concat(" (Requires eXist-db ", app:requires-to-english($app/requires), ".)")
+                            else
                                 ()
                             }
                         <br/>
@@ -213,14 +213,14 @@ declare function app:find-version($apps as element()*, $procVersion as xs:string
 
 declare function app:requires-to-english($requires as element()) {
     (: we assume @processor="http://exist.db-org/" :)
-    if ($requires/@version) then 
-        concat(' version ', $requires/@version)
-    else if ($requires/@semver) then 
-        concat(' version ', $requires/@semver)
-    else if ($requires/@semver-min) then 
-        concat(' version ', $requires/@semver-min, ' or later')
-    else if ($requires/@semver-max) then 
-        concat(' version ', $requires/@semver-max, ' or earlier')
-    else 
-        ' version 2.2'
+    if ($requires/@version) then
+        concat(" version ", $requires/@version)
+    else if ($requires/@semver) then
+        concat(" version ", $requires/@semver)
+    else if ($requires/@semver-min) then
+        concat(" version ", $requires/@semver-min, " or later")
+    else if ($requires/@semver-max) then
+        concat(" version ", $requires/@semver-max, " or earlier")
+    else
+        " version 2.2"
 };

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -12,13 +12,6 @@ declare function app:publish($node as node(), $model as map(*), $publish as xs:b
         ()
 };
 
-declare function app:title($node as node(), $model as map(*), $mode as xs:string?) {
-    let $package-id := request:get-parameter('package-id', ())
-    let $package := collection($config:public)//app[abbrev = $package-id]
-    return
-        $package/title/string()
-};
-
 declare function app:list-packages($node as node(), $model as map(*), $mode as xs:string?) {
     for $app in collection($config:public)//app
     let $show-details := false()

--- a/modules/feed.xql
+++ b/modules/feed.xql
@@ -5,7 +5,7 @@ import module namespace config="http://exist-db.org/xquery/apps/config" at "conf
 declare option exist:serialize "method=xml media-type=application/atom+xml";
 
 declare function local:feed-entries() {
-    let $repoURL := concat(substring-before(request:get-url(), 'public-repo/'), 'public-repo/')
+    let $repoURL := concat(substring-before(request:get-url(), "public-repo/"), "public-repo/")
     for $app in collection($config:public)//app
     let $icon :=
         if ($app/icon) then
@@ -15,10 +15,11 @@ declare function local:feed-entries() {
                 $repoURL || "public/" || $app/icon[1]
         else
             $repoURL || "resources/images/package.png"
+    let $required-exist-version := $app/requires[@processor eq "http://exist-db.org"]/(@version, @semver-min)[1]
     let $info-url :=
-        concat($repoURL, 'packages/', $app/abbrev[not(@type eq "legacy")], '.html',
-            if ($app/requires/@*[not(name() = 'processor')]) then
-                concat('?eXist-db-min-version=', ($app/requires/@version, $app/requires/@semver-min)[1])
+        concat($repoURL, "packages/", $app/abbrev[not(@type eq "legacy")], ".html",
+            if ($required-exist-version) then
+                concat("?eXist-db-min-version=", $required-exist-version)
             else
                 ()
         )
@@ -51,26 +52,26 @@ declare function local:feed-entries() {
                     <dt>Title:</dt>
                     <dd>{ $title/string() }</dd>
                     <dt>Author(s):</dt>
-                    <dd>{ if ($authors[1] ne '') then string-join($authors, ', ') else '(No author provided)'}</dd>
+                    <dd>{ if (exists($authors[. ne ""])) then string-join($authors, ", ") else "(No author provided)"}</dd>
                     <dt>Version:</dt>
-                    <dd>{ if ($version ne '') then $version/string() else '(No version information provided)' }</dd>
+                    <dd>{ if ($version ne "") then $version/string() else "(No version information provided)" }</dd>
                     <dt>Description:</dt>
-                    <dd>{ if ($description ne '') then $description/string() else '(No description provided)'}</dd>
+                    <dd>{ if ($description ne "") then $description/string() else "(No description provided)"}</dd>
                     <dt>License:</dt>
-                    <dd>{ if ($license ne '') then $license/string() else '(No license specified)' }</dd>
+                    <dd>{ if ($license ne "") then $license/string() else "(No license specified)" }</dd>
                     <dt>Website:</dt>
-                    <dd>{ if ($website/node()) then <a href="{$website}">{ $website/string() }</a> else '(No website provided)' }</dd>
+                    <dd>{ if ($website/node()) then <a href="{$website}">{ $website/string() }</a> else "(No website provided)" }</dd>
                     <dt>Change Log:</dt>
-                    <dd>{ if ($has-changelog) then <dl>{ $changes }</dl> else '(No change log provided)' }</dd>
+                    <dd>{ if ($has-changelog) then <dl>{ $changes }</dl> else "(No change log provided)" }</dd>
                 </dl>
             </div>
         </div>
     order by $updated
     return
         <entry xmlns="http://www.w3.org/2005/Atom">
-            <title>{$title || ' ' || $version}</title>
+            <title>{$title || " " || $version}</title>
             <link href="{$info-url}" />
-            <id>{'urn:uuid:' || util:uuid($title || '-' || $version)}</id>
+            <id>{"urn:uuid:" || util:uuid($title || "-" || $version)}</id>
             <updated>{$updated}</updated>
             <content type="xhtml">{$content}</content>
             {
@@ -85,11 +86,11 @@ declare function local:feed-entries() {
 };
 
 declare function local:feed() {
-    let $title := 'eXist-db Public Package Repository'
-    let $subtitle := 'Repository for apps and libraries on eXist-db.org.'
+    let $title := "eXist-db Public Package Repository"
+    let $subtitle := "Repository for apps and libraries on eXist-db.org."
     let $self-href := request:get-url()
-    let $id := 'urn:uuid:' || util:uuid('existdb-public-package-repository-feed')
-    let $updated := xmldb:last-modified($config:public, 'apps.xml')
+    let $id := "urn:uuid:" || util:uuid("existdb-public-package-repository-feed")
+    let $updated := xmldb:last-modified($config:public, "apps.xml")
     let $feed-entries := local:feed-entries()
     return
         <feed xmlns="http://www.w3.org/2005/Atom">

--- a/modules/feed.xql
+++ b/modules/feed.xql
@@ -16,7 +16,7 @@ declare function local:feed-entries() {
         else
             $repoURL || "resources/images/package.png"
     let $info-url :=
-        concat($repoURL, 'packages/', $app/abbrev, '.html',
+        concat($repoURL, 'packages/', $app/abbrev[not(@type eq "legacy")], '.html',
             if ($app/requires/@*[not(name() = 'processor')]) then
                 concat('?eXist-db-min-version=', ($app/requires/@version, $app/requires/@semver-min)[1])
             else

--- a/modules/find.xql
+++ b/modules/find.xql
@@ -16,16 +16,16 @@ let $version := request:get-parameter("version", ())
 let $zip := request:get-parameter("zip", ())
 let $info := request:get-parameter("info", ())
 let $procVersion := request:get-parameter("processor", "2.2.0")
-let $apps :=
+let $app :=
     if ($name) then
-        collection($config:app-root || "/public")//app[name = $name]
+        collection($config:app-root || "/public")//app[name eq $name]
     else
-        collection($config:app-root || "/public")//app[abbrev = $abbrev]
-let $path := app:find-version($apps | $apps/other/version, $procVersion, $version, $semVer, $minVersion, $maxVersion)
+        collection($config:app-root || "/public")//app[abbrev eq $abbrev]
+let $compatible-xar := app:find-version($app | $app/other/version, $procVersion, $version, $semVer, $minVersion, $maxVersion)
 return
-    if ($path) then
+    if ($compatible-xar) then
         let $rel-public :=
-            if(contains(request:get-url(), "/modules/")) then
+            if (contains(request:get-url(), "/modules/")) then
                 "../public/"
             else
                 "public/"
@@ -33,10 +33,10 @@ return
             if ($info) then
                 <found>{$app}</found>
             else if ($zip) then
-                response:redirect-to(xs:anyURI($rel-public || $path || ".zip"))
-            else 
-                response:redirect-to(xs:anyURI($rel-public || $path))
+                response:redirect-to(xs:anyURI($rel-public || $compatible-xar || ".zip"))
+            else
+                response:redirect-to(xs:anyURI($rel-public || $compatible-xar))
     else (
         response:set-status-code(404),
-        <p>Package file {$path} not found!</p>
+        <p>Package file {$compatible-xar} not found!</p>
     )

--- a/modules/scan.xql
+++ b/modules/scan.xql
@@ -32,9 +32,14 @@ declare function scanrepo:process($apps as element(app)*) {
     group by $name := $app/name
     return
         let $newest := scanrepo:find-newest($app, (), ())
+        let $abbrevs := distinct-values($app/abbrev)
         return
             <app>
-                { $newest/@*, $newest/* }
+                { 
+                    $newest/@*, 
+                    $newest/*, 
+                    $abbrevs[not(. = $newest/abbrev)] ! element abbrev { attribute type { "legacy" }, . }
+                }
                 <other>
                 {
                     reverse(


### PR DESCRIPTION
## Background

When .xars are "published" to the public-repo, apps with the same expath-pkg.xml `package/@name` (the app’s unique URI, as opposed to its shorthand `@abbrev`) are gathered into a single <app> element, containing metadata about the app from expath-pkg.xml and repo.xml (e.g., name, title, authors, available versions, etc.). 

Previously, only the newest package’s “abbrev” was preserved in this `<app>` element; other values for the “abbrev” that might’ve been used in older versions of the app were discarded. This made lookup of a package by an older “abbrev” impossible. 

This PR ensures legacy “abbrev” values are preserved in this app metadata so that lookups of apps by their legacy values is possible. 

For example, given an app like eXist Documentation, its previous abbrev was “doc” was changed in 0.6.0 to “exist-documentation”. Since then, requests for the app by “abbrev=doc” failed. With this PR, the legacy abbrev "doc" is preserved, and lookup of the app by either its old or new abbrev is possible.